### PR TITLE
Update imports to reflect new repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Documents provided for the AsyncAPI Parser can be in the `.yaml` or `.json` form
 To install the AsyncAPI Parser package, run:
 
 ```bash
-go get github.com/asyncapi/parser/...
+go get github.com/asyncapi/parser-go/...
 ```
 
 ## Usage

--- a/cmd/api-parser/main.go
+++ b/cmd/api-parser/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/asyncapi/parser/internal/cli"
+	"github.com/asyncapi/parser-go/internal/cli"
 
 	"github.com/docopt/docopt-go"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/asyncapi/parser
+module github.com/asyncapi/parser-go
 
 go 1.12
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,10 +1,10 @@
 package cli
 
 import (
-	"github.com/asyncapi/parser/pkg/parser"
-	"github.com/asyncapi/parser/pkg/schema"
-	asyncapi "github.com/asyncapi/parser/pkg/schema/asyncapi/v2"
-	openapi "github.com/asyncapi/parser/pkg/schema/openapi/v2"
+	"github.com/asyncapi/parser-go/pkg/parser"
+	"github.com/asyncapi/parser-go/pkg/schema"
+	asyncapi "github.com/asyncapi/parser-go/pkg/schema/asyncapi/v2"
+	openapi "github.com/asyncapi/parser-go/pkg/schema/openapi/v2"
 
 	"github.com/docopt/docopt-go"
 	"github.com/pkg/errors"

--- a/pkg/jsonpath/loader.go
+++ b/pkg/jsonpath/loader.go
@@ -1,7 +1,7 @@
 package jsonpath
 
 import (
-	"github.com/asyncapi/parser/pkg/decode"
+	"github.com/asyncapi/parser-go/pkg/decode"
 
 	"net/http"
 	"os"

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1,9 +1,9 @@
 package parser
 
 import (
-	"github.com/asyncapi/parser/pkg/decode"
-	"github.com/asyncapi/parser/pkg/jsonpath"
-	hlsp "github.com/asyncapi/parser/pkg/parser/v2"
+	"github.com/asyncapi/parser-go/pkg/decode"
+	"github.com/asyncapi/parser-go/pkg/jsonpath"
+	hlsp "github.com/asyncapi/parser-go/pkg/parser/v2"
 
 	"encoding/json"
 	"io"

--- a/pkg/parser/v2/hlsp.go
+++ b/pkg/parser/v2/hlsp.go
@@ -1,9 +1,9 @@
 package v2
 
 import (
-	parserErrors "github.com/asyncapi/parser/pkg/error"
-	"github.com/asyncapi/parser/pkg/jsonpath"
-	"github.com/asyncapi/parser/pkg/schema/asyncapi/v2"
+	parserErrors "github.com/asyncapi/parser-go/pkg/error"
+	"github.com/asyncapi/parser-go/pkg/jsonpath"
+	"github.com/asyncapi/parser-go/pkg/schema/asyncapi/v2"
 
 	"github.com/pkg/errors"
 )

--- a/pkg/parser/v2/hlsp_test.go
+++ b/pkg/parser/v2/hlsp_test.go
@@ -1,8 +1,8 @@
 package v2
 
 import (
-	"github.com/asyncapi/parser/pkg/decode"
-	"github.com/asyncapi/parser/pkg/jsonpath"
+	"github.com/asyncapi/parser-go/pkg/decode"
+	"github.com/asyncapi/parser-go/pkg/jsonpath"
 	. "github.com/onsi/gomega"
 
 	"fmt"

--- a/pkg/schema/asyncapi/v2/message_processor.go
+++ b/pkg/schema/asyncapi/v2/message_processor.go
@@ -1,7 +1,7 @@
 package v2
 
 import (
-	parserErrors "github.com/asyncapi/parser/pkg/error"
+	parserErrors "github.com/asyncapi/parser-go/pkg/error"
 
 	"github.com/pkg/errors"
 

--- a/pkg/schema/asyncapi/v2/schema_parser.go
+++ b/pkg/schema/asyncapi/v2/schema_parser.go
@@ -1,6 +1,6 @@
 package v2
 
-import parseSchema "github.com/asyncapi/parser/pkg/schema"
+import parseSchema "github.com/asyncapi/parser-go/pkg/schema"
 
 var (
 	parser = parseSchema.NewParser(schema)

--- a/pkg/schema/jsonschema/draft07/jsonschma.go
+++ b/pkg/schema/jsonschema/draft07/jsonschma.go
@@ -1,6 +1,6 @@
 package draft07
 
-import parseSchema "github.com/asyncapi/parser/pkg/schema"
+import parseSchema "github.com/asyncapi/parser-go/pkg/schema"
 
 var parser = parseSchema.NewParser(schema)
 

--- a/pkg/schema/openapi/v2/openapi.go
+++ b/pkg/schema/openapi/v2/openapi.go
@@ -1,9 +1,9 @@
 package v2
 
 import (
-	parserErrors "github.com/asyncapi/parser/pkg/error"
-	parserSchema "github.com/asyncapi/parser/pkg/schema"
-	"github.com/asyncapi/parser/pkg/schema/jsonschema/draft07"
+	parserErrors "github.com/asyncapi/parser-go/pkg/error"
+	parserSchema "github.com/asyncapi/parser-go/pkg/schema"
+	"github.com/asyncapi/parser-go/pkg/schema/jsonschema/draft07"
 
 	"github.com/pkg/errors"
 

--- a/pkg/schema/parser.go
+++ b/pkg/schema/parser.go
@@ -1,7 +1,7 @@
 package schema
 
 import (
-	parserErrors "github.com/asyncapi/parser/pkg/error"
+	parserErrors "github.com/asyncapi/parser-go/pkg/error"
 
 	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"


### PR DESCRIPTION
This is a result of rename of the repo to match the pattern:
parser-go
converter-go
parser-js
converter-js