### PR TITLE
docs: Supported Async API version documented in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The AsyncAPI Parser validates AsyncAPI documents according to dedicated schemas.
 
 Documents provided for the AsyncAPI Parser can be in the `.yaml` or `.json` formats. If a document is invalid, the parser provides a message listing all errors. If a document is valid, the parser provides dereferenced output. During the dereference process the AsyncAPI parser substitutes a reference with a full definition. The dereferenced output is always in the `.json` format.
 
+> :warning: This package doesn't support AsyncAPI 1.x anymore. We recommend to upgrade to the latest AsyncAPI version using the [AsyncAPI converter](https://github.com/asyncapi/converter-js). If you need to convert documents on the fly, you may use the [Node.js](https://github.com/asyncapi/converter-js) or [Go](https://github.com/asyncapi/converter-go) converters.
+
 ## Prerequisites
 
 - [Golang](https://golang.org/dl/) version 1.12+


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- For new users checking the tool for the first time it is not possible to know what versino of AsyncAPI is currently supported right away. The proposal here is to include this information on the README.md file of the project.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Resolves #52 