### PR TITLE
chore: update release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       matrix:
         go: 
-          - '1.14'
-          - '1.13'
-          - '1.12' 
+          - '1.17'
+          - '1.16'
+          - '1.15' 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -34,9 +34,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Setup Go
-        uses: actions/setup-go@v1.1.2
+        uses: actions/setup-go@v2
         with:
-          go-version: '1.14'
+          go-version: '1.17'
       - name: Invoking go vet and binaries generation
         run: |
           go vet ./...


### PR DESCRIPTION
**Description**

[release.yml](.github/workflows/release.yml) action is broken since it is using some old setup-go action that performs forbidden steps. 

This PR updates the action + the versions on test matrix in order to use a more recent go version.