### PR TITLE
chore: use same setup-go action version for all steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Setup Go
-        uses: actions/setup-go@v1.1.2
+        uses: actions/setup-go@v2
         with:
           go-version: '${{ matrix.go }}'
       - name: Invoking go test


### PR DESCRIPTION
**Description**

I missed one more change in the file. We do setup-go twice and I only changed it in one place here asyncapi#80. 😫 😫