### PR TITLE
ci: update Go versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       matrix:
         go: 
+          - '1.18'
           - '1.17'
           - '1.16'
-          - '1.15' 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - name: Invoking go vet and binaries generation
         run: |
           go vet ./...


### PR DESCRIPTION
**Description**

This PR updates Go versions on CI release GH action. Also removes the support for v1.15 as it doesn't have the built-in `embed` package, required now since https://github.com/asyncapi/parser-go/pull/117. 

**Related issue(s)**
It fixes the release action: https://github.com/asyncapi/parser-go/actions/runs/2219687174