### PR TITLE
docs: fix links in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You can use the AsyncAPI Parser in two ways:
 ## Contribution
 
 If you have a feature request, add it as an issue or propose changes in a pull request (PR).
-If you create a feature request, use the dedicated **Feature request** issue template. When you create a PR, follow the contributing rules described in the [`CONTRIBUTING.md`](CONTRIBUTING.md) document.
+If you create a feature request, use the dedicated **Feature request** issue template. When you create a PR, follow the contributing rules described in the [`CONTRIBUTING.md`](https://github.com/asyncapi/.github/blob/master/CONTRIBUTING.md) document.
 
 ## Roadmap
 


### PR DESCRIPTION
Context
this PR is supposed to fix all the [broken links](https://github.com/asyncapi/parser-go/runs/6143349401?check_suite_focus=true) in markdown files across the repo.

apparently, there is only one broken link and that is the CONTRIBUTING.md file. I guess we can use the default one in `.github` repo. 
If this repo is supposed to have its own contributing guidelines, please close this PR.