### PR TITLE
feat: update asyncapi/spec-json-schemas to 2.14.0 supporting 2.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/asyncapi/converter-go v0.0.0-20190802111537-d8459b2bd403
-	github.com/asyncapi/spec-json-schemas/v2 v2.13.2
+	github.com/asyncapi/spec-json-schemas/v2 v2.14.0
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/onsi/gomega v1.5.0
 	github.com/pkg/errors v0.8.1


### PR DESCRIPTION
**Description**

This PR updates `github.comasyncapi/spec-json-schemas` package to `2.14.0`, which adds the schema for AsyncAPI 2.4.

Pending to push the `go.sum` once the release of AsyncAPI 2.4 is out. 