### PR TITLE
fix: remove Gomega dependency in favour of Testify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/asyncapi/converter-go v0.3.0
 	github.com/asyncapi/spec-json-schemas/v4 v4.3.1
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
-	github.com/onsi/gomega v1.27.10
+	github.com/onsi/gomega v1.27.10 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190809123943-df4f5c81cb3b // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/onsi/gomega v1.27.10 // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/stretchr/testify v1.8.4
+	github.com/stretchr/testify v1.8.2
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190809123943-df4f5c81cb3b // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190809123943-df4f5c81cb3b h1:6cLsL+2FW6dRAdl5iMtHgRogVCff0QpRi9653YmdcJA=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190809123943-df4f5c81cb3b/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/pkg/decode/decode_test.go
+++ b/pkg/decode/decode_test.go
@@ -1,15 +1,14 @@
 package decode
 
 import (
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 
 	"strings"
 	"testing"
 )
 
 func TestToMap1(t *testing.T) {
-	g := NewWithT(t)
 	reader := strings.NewReader("123")
 	_, err := ToMap(reader)
-	g.Expect(err).Should(HaveOccurred())
+	assert.Error(t, err)
 }

--- a/pkg/error/error_test.go
+++ b/pkg/error/error_test.go
@@ -3,23 +3,21 @@ package error
 import (
 	"testing"
 
-	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 
-	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 )
 
 var errTest = errors.New("test error")
 
 func TestNewNil(t *testing.T) {
-	g := NewWithT(t)
 	err := New()
-	g.Expect(err).To(BeNil())
+	assert.NoError(t, err)
 }
 
 func TestNew(t *testing.T) {
-	g := NewWithT(t)
 	err := New(errTest)
-	g.Expect(err.Error()).To(Equal("test error"))
+	assert.Error(t, err, "test error")
 }
 
 func TestJoin(t *testing.T) {
@@ -46,9 +44,8 @@ func TestJoin(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			g := NewWithT(t)
 			errMsg := Join(tC.errs, "|")
-			g.Expect(errMsg).To(Equal(tC.expectedMessage))
+			assert.Equal(t, tC.expectedMessage, errMsg)
 		})
 	}
 }

--- a/pkg/jsonpath/loader_test.go
+++ b/pkg/jsonpath/loader_test.go
@@ -1,14 +1,14 @@
 package jsonpath
 
 import (
-	. "github.com/onsi/gomega"
-
 	"bytes"
 	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func data() io.ReadCloser {
@@ -45,13 +45,13 @@ func TestLoader(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			g := NewWithT(t)
 			loader := NewRefLoader(&ClientMock{})
 			actual, err := loader.Load(test.name)
-			g.Expect(err).ShouldNot(HaveOccurred())
-			g.Expect(actual).To(Equal(map[string]interface{}{
+			assert.NoError(t, err)
+			expected := map[string]interface{}{
 				"test": "me",
-			}))
+			}
+			assert.Equal(t, expected, actual)
 		})
 	}
 }
@@ -65,10 +65,9 @@ func TestLoaderErr(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			g := NewWithT(t)
 			loader := NewRefLoader(&ClientMock{})
 			_, err := loader.Load(test.name)
-			g.Expect(err).Should(HaveOccurred())
+			assert.Error(t, err)
 		})
 	}
 }

--- a/pkg/jsonpath/reference_test.go
+++ b/pkg/jsonpath/reference_test.go
@@ -2,8 +2,9 @@ package jsonpath
 
 import (
 	"fmt"
-	. "github.com/onsi/gomega"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDecodeItemName(t *testing.T) {
@@ -26,10 +27,9 @@ func TestDecodeItemName(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`Expect:"%s"`, test.expected), func(t *testing.T) {
-			g := NewWithT(t)
 			actual, err := DecodeEntryKey(test.name)
-			g.Expect(err).ShouldNot(HaveOccurred())
-			g.Expect(actual).To(Equal(test.expected))
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, actual)
 		})
 	}
 }
@@ -51,9 +51,8 @@ func TestDecodeItemNameErr(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`Expect err:"%s"`, test.name), func(t *testing.T) {
-			g := NewWithT(t)
 			_, err := DecodeEntryKey(test.name)
-			g.Expect(err).Should(HaveOccurred())
+			assert.Error(t, err)
 		})
 	}
 }
@@ -65,8 +64,7 @@ func TestNewReference(t *testing.T) {
 	}{
 		{
 			strRef: "/test/path#/test/me/plz",
-			expected:
-			Ref{
+			expected: Ref{
 				pointer: "/test/me/plz",
 				uri:     "/test/path",
 				path:    []string{"test", "me", "plz"},
@@ -75,10 +73,9 @@ func TestNewReference(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.strRef, func(t *testing.T) {
-			g := NewWithT(t)
 			ref, err := NewRef(test.strRef)
-			g.Expect(err).ShouldNot(HaveOccurred())
-			g.Expect(ref).To(Equal(test.expected))
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, ref)
 		})
 	}
 }
@@ -89,15 +86,13 @@ func TestNewReference_ShouldReturnError(t *testing.T) {
 		"",
 	} {
 		t.Run(test, func(t *testing.T) {
-			g := NewWithT(t)
 			_, err := NewRef(test)
-			g.Expect(err).Should(HaveOccurred())
+			assert.Error(t, err)
 		})
 	}
 }
 
 func TestGetRefObject(t *testing.T) {
-	g := NewWithT(t)
 	v := map[string]interface{}{
 		"test": map[string]interface{}{
 			"me": map[string]interface{}{
@@ -106,8 +101,10 @@ func TestGetRefObject(t *testing.T) {
 		},
 	}
 	actual, err := GetRefObject([]string{"test", "me"}, v)
-	g.Expect(err).ShouldNot(HaveOccurred())
-	g.Expect(actual).To(Equal(map[string]interface{}{
+	assert.NoError(t, err)
+
+	expected := map[string]interface{}{
 		"plz": true,
-	}))
+	}
+	assert.Equal(t, expected, actual)
 }

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 )
 
 const oneOfJSONFile = "./testdata/oneof.json"
@@ -19,13 +19,12 @@ var (
 )
 
 func TestMessageProcessor_BuildParser(t *testing.T) {
-	g := NewWithT(t)
 	parse := noopMessageProcessor.BuildParser()
 	writer := bytes.NewBufferString("")
 	reader, err := os.Open(oneOfJSONFile)
-	g.Expect(err).ShouldNot(HaveOccurred())
+	assert.NoError(t, err)
 	err = parse(reader, writer)
-	g.Expect(err).ShouldNot(HaveOccurred())
+	assert.NoError(t, err)
 }
 
 func TestNewReader(t *testing.T) {
@@ -54,10 +53,9 @@ func TestNewReader(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			g := NewWithT(t)
 			r, err := NewReader(test.doc)
-			g.Expect(err).ShouldNot(HaveOccurred())
-			g.Expect(r).ShouldNot(BeNil())
+			assert.NoError(t, err)
+			assert.NotNil(t, r)
 		})
 	}
 }

--- a/pkg/parser/v2/hlsp_test.go
+++ b/pkg/parser/v2/hlsp_test.go
@@ -3,7 +3,7 @@ package v2
 import (
 	"github.com/asyncapi/parser-go/pkg/decode"
 	"github.com/asyncapi/parser-go/pkg/jsonpath"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 
 	"fmt"
 	"net/http"
@@ -53,16 +53,15 @@ func TestParser_Parse(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			g := NewWithT(t)
 			refLoader := jsonpath.NewRefLoader(http.DefaultClient)
 			p := NewParser(refLoader, test.blackListedPaths...)
 			err := p.Parse(test.doc)
 			if test.expectedErr {
-				g.Expect(err).Should(HaveOccurred())
+				assert.Error(t, err)
 				return
 			}
-			g.Expect(err).ShouldNot(HaveOccurred())
-			g.Expect(test.doc).To(Equal(test.expectedDoc))
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedDoc, test.doc)
 		})
 	}
 }

--- a/pkg/schema/asyncapi/v2/message_processor_test.go
+++ b/pkg/schema/asyncapi/v2/message_processor_test.go
@@ -1,13 +1,13 @@
 package v2
 
 import (
-	. "github.com/onsi/gomega"
-
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_schemaFormat(t *testing.T) {
@@ -38,9 +38,8 @@ func Test_schemaFormat(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
 			format := schemaFormat(tt.args.m)
-			g.Expect(format).To(Equal(tt.want))
+			assert.Equal(t, tt.want, format)
 		})
 	}
 }
@@ -70,11 +69,11 @@ func TestDispatcher_Add(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
 			err := tt.d.Add(tt.args.pm, tt.args.labels...)
-			g.Expect(err).ShouldNot(HaveOccurred())
+			assert.NoError(t, err)
+
 			for _, label := range tt.args.labels {
-				g.Expect(tt.d[label]).NotTo(BeNil())
+				assert.NotNil(t, tt.d[label])
 			}
 		})
 	}
@@ -112,19 +111,18 @@ func Test_extractMessages(t *testing.T) {
 			panic(fmt.Sprintf("invalid test data in: '%s'", tt.channelFile))
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
 			got, err := extractMessages(channel)
 			if tt.wantErr {
-				g.Expect(err).Should(HaveOccurred())
+				assert.NoError(t, err)
 				return
 			}
-			g.Expect(got).To(Equal(expectedMsgs))
+
+			assert.Equal(t, expectedMsgs, got)
 		})
 	}
 }
 
 func TestBuildMessageProcessor(t *testing.T) {
-	g := NewWithT(t)
 	testErr := errors.New("test error")
 	d := Dispatcher{
 		"test1": func(_ interface{}) error {
@@ -142,7 +140,7 @@ func TestBuildMessageProcessor(t *testing.T) {
 	}
 	processMessages := BuildMessageProcessor(d)
 	err = processMessages(document)
-	g.Expect(err).Should(HaveOccurred())
+	assert.Error(t, err)
 }
 
 func load(path string, v interface{}, t *testing.T) error {

--- a/pkg/schema/jsonschema/draft07/jsonschema_test.go
+++ b/pkg/schema/jsonschema/draft07/jsonschema_test.go
@@ -1,17 +1,16 @@
 package draft07
 
 import (
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 
 	"encoding/json"
 	"testing"
 )
 
 func TestParseInvalidSchemaObject(t *testing.T) {
-	g := NewWithT(t)
 	v := "this will not work"
 	err := Parse(v)
-	g.Expect(err).Should(HaveOccurred())
+	assert.Error(t, err)
 }
 
 func TestParse(t *testing.T) {
@@ -31,7 +30,7 @@ func TestParse(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := Parse(&test.v)
-			NewWithT(t).Expect(err).ShouldNot(HaveOccurred())
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/pkg/schema/openapi/v2/openapi_test.go
+++ b/pkg/schema/openapi/v2/openapi_test.go
@@ -1,12 +1,12 @@
 package v2
 
 import (
-	. "github.com/onsi/gomega"
-
 	"encoding/json"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParse(t *testing.T) {
@@ -38,17 +38,16 @@ func TestParse(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			g := NewWithT(t)
 			msg := loadMsg(test.msg, t)
 			err := Parse(&msg)
-			g.Expect(err).ShouldNot(HaveOccurred())
+			assert.NoError(t, err)
 
 			payload, err := json.Marshal(msg)
 			if err != nil {
 				t.Fatal("data marshalling error", err)
 			}
 			expected := open(test.expected, t)
-			g.Expect(payload).Should(MatchJSON(expected))
+			assert.JSONEq(t, string(expected), string(payload))
 		})
 	}
 }


### PR DESCRIPTION
**Description**

Gomega library was being used for asserting in tests. However, sometimes it breaks after upgrading even between minor versions. 
As we already have Testify, which is the most widely used test framework in Go community, we don't need Gomega so I'm removing it.

It also downgrades testify to 1.8.2 as newer are incompatible with go <=1.19

