### PR TITLE
fix: set compatible semantic-release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,4 +58,4 @@ jobs:
           GIT_AUTHOR_EMAIL: info@asyncapi.io
           GIT_COMMITTER_NAME: asyncapi-bot
           GIT_COMMITTER_EMAIL: info@asyncapi.io
-        run: npx semantic-release
+        run: npx semantic-release@19.0.4


### PR DESCRIPTION
**Description**

Another attempt to fix the release workflow. 
Using a particular version of the semantic-release. The same as we use in https://github.com/asyncapi/.github/blob/master/.github/workflows/if-nodejs-release.yml#L105C8-L117C41.

Hope this fix [the issue](https://github.com/asyncapi/parser-go/actions/runs/5975850148/job/16212605495).